### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ languages:
 - python
 products:
 - azure-synapse-analytics
-- microsoft-graph-data-connect-api
+- microsoft-graph-data-connect
 - power-bi
 ---
 


### PR DESCRIPTION
taxonomy value of connect-api has been removed from the taxonomy service. The "api" suffix is no longer valid.